### PR TITLE
feat: add filtering and sorting to challenge list

### DIFF
--- a/src/data/challenges.ts
+++ b/src/data/challenges.ts
@@ -1,4 +1,6 @@
-export const challenges = [
+import { Challenges } from "@/ui/components/modules/challenge-list/challenge-list.types";
+
+export const challenges: Challenges[] = [
   {
     id: 1,
     name: "Two Sum",

--- a/src/ui/components/modules/challenge-list/active-filters.tsx
+++ b/src/ui/components/modules/challenge-list/active-filters.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Flex, Badge } from "@radix-ui/themes";
+import { X } from "lucide-react";
+import { ChallengeFilters } from "./challenge-list.types";
+
+interface Props {
+  filters: ChallengeFilters;
+  onRemoveDifficulty: () => void;
+  onRemoveTag: (tag: string) => void;
+  onRemoveSort: () => void;
+  onRemoveSearch: () => void;
+}
+
+export const ActiveFilters = ({
+  filters,
+  onRemoveDifficulty,
+  onRemoveTag,
+  onRemoveSort,
+  onRemoveSearch,
+}: Props) => {
+  const hasFilters =
+    filters.difficulty !== "All" ||
+    filters.tags.length > 0 ||
+    filters.sortBy !== "none" ||
+    filters.search.trim() !== "";
+
+  if (!hasFilters) return null;
+
+  return (
+    <Flex gap="2" wrap="wrap" style={{ padding: "0 5%", marginBottom: "12px" }}>
+      <span style={{ fontSize: "14px", fontWeight: 600, alignSelf: "center" }}>
+        Active filters:
+      </span>
+
+      {filters.difficulty !== "All" && (
+        <Badge size="2" variant="solid" style={{ cursor: "pointer" }} onClick={onRemoveDifficulty}>
+          Difficulty: {filters.difficulty}
+          <X size={14} style={{ marginLeft: 4 }} />
+        </Badge>
+      )}
+
+      {filters.tags.map((tag) => (
+        <Badge key={tag} size="2" variant="solid" style={{ cursor: "pointer" }} onClick={() => onRemoveTag(tag)}>
+          Tag: {tag}
+          <X size={14} style={{ marginLeft: 4 }} />
+        </Badge>
+      ))}
+
+      {filters.sortBy !== "none" && (
+        <Badge size="2" variant="solid" style={{ cursor: "pointer" }} onClick={onRemoveSort}>
+          Sort: {filters.sortBy}
+          <X size={14} style={{ marginLeft: 4 }} />
+        </Badge>
+      )}
+
+      {filters.search.trim() !== "" && (
+        <Badge size="2" variant="solid" style={{ cursor: "pointer" }} onClick={onRemoveSearch}>
+         Search: &quot;{filters.search}&quot;
+          <X size={14} style={{ marginLeft: 4 }} />
+        </Badge>
+      )}
+    </Flex>
+  );
+};

--- a/src/ui/components/modules/challenge-list/challenge-list.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-list.tsx
@@ -11,7 +11,7 @@ import { useChallengeFilters } from "./use-challenge-filters";
 import { DifficultyFilter } from "./difficulty-filter";
 import { TagFilter } from "./tag-filter";
 import { SortDropdown } from "./sort-dropdown";
-import { Flex, Button } from "@radix-ui/themes";
+import { Flex, Button, Badge } from "@radix-ui/themes";
 
 export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
   const { filters, updateFilters, resetFilters } = useChallengeFilters();
@@ -94,7 +94,20 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
                     {challenge.name}
                   </RadixNextLink>
                 </td>
-                <td>{challenge.difficulty}</td>
+                <td>
+                  <Badge
+                    color={
+                      challenge.difficulty === "Easy"
+                      ? "green"
+                      : challenge.difficulty === "Medium"
+                      ? "yellow"
+                      : "red"
+                    }
+                    variant="soft"
+                    >
+                  {challenge.difficulty}
+                  </Badge>
+                  </td>
                 <td>{challenge.tags.join(", ")}</td>
               </tr>
             ))

--- a/src/ui/components/modules/challenge-list/challenge-list.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-list.tsx
@@ -5,7 +5,7 @@ import classes from "./challenge-list.module.scss";
 import { RadixNextLink } from "@/ui/components/core/radix-next-link/radix-next-link";
 import { useMemo } from "react";
 import SearchBar from "./search-bar";
-import { filterAndSortChallenges, getAllUniqueTags } from "./challenge-list.utils";
+import { filterAndSortChallenges, getAllUniqueTags, getDfifficultyCounts } from "./challenge-list.utils";
 import { Challenges } from "./challenge-list.types";
 import { useChallengeFilters } from "./use-challenge-filters";
 import { DifficultyFilter } from "./difficulty-filter";
@@ -21,6 +21,8 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
   const filteredChallenges = useMemo(() => {
     return filterAndSortChallenges(challenges, filters);
   }, [challenges, filters]);
+
+  const difficultyCounts = useMemo(() => getDfifficultyCounts(challenges), [challenges]);
 
   const hasActiveFilters =
     filters.difficulty !== "All" ||
@@ -42,6 +44,7 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
           <DifficultyFilter
             selected={filters.difficulty}
             onChange={(difficulty) => updateFilters({ difficulty })}
+            counts={difficultyCounts}
           />
           <Flex gap="2" align="center">
             <SortDropdown value={filters.sortBy} onChange={(sortBy) => updateFilters({ sortBy })} />

--- a/src/ui/components/modules/challenge-list/challenge-list.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-list.tsx
@@ -12,6 +12,7 @@ import { DifficultyFilter } from "./difficulty-filter";
 import { TagFilter } from "./tag-filter";
 import { SortDropdown } from "./sort-dropdown";
 import { Flex, Button, Badge } from "@radix-ui/themes";
+import { ActiveFilters } from "./active-filters";
 
 export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
   const { filters, updateFilters, resetFilters } = useChallengeFilters();
@@ -69,6 +70,13 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
       </div>
 
       {/* Table */}
+      <ActiveFilters
+        filters={filters}
+        onRemoveDifficulty={() => updateFilters({ difficulty: "All" })}
+        onRemoveTag={(tag) => updateFilters({ tags: filters.tags.filter((t) => t !== tag) })}
+        onRemoveSort={() => updateFilters({ sortBy: "none" })}
+        onRemoveSearch={() => updateFilters({ search: "" })}
+      />
       <table className={classes.challengesTable}>
         <thead>
           <tr>

--- a/src/ui/components/modules/challenge-list/challenge-list.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-list.tsx
@@ -25,7 +25,7 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
   const hasActiveFilters =
     filters.difficulty !== "All" ||
     filters.tags.length > 0 ||
-    filters.sortBy !== "newest" ||
+    filters.sortBy !== "none" ||
     filters.search.trim() !== "";
 
   return (

--- a/src/ui/components/modules/challenge-list/challenge-list.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-list.tsx
@@ -81,10 +81,22 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
         <tbody>
           {filteredChallenges.length === 0 ? (
             <tr>
-              <td colSpan={4} style={{ textAlign: "center", padding: "12px 0" }}>
-                No challenges found
-              </td>
-            </tr>
+              <td colSpan={4} style={{ textAlign: "center", padding: "40px 20px" }}>
+                <div style={{ display:"flex", flexDirection: "column", alignItems:"center", gap:"12px"}}>
+                  <span style={{ fontSize: "48px" }}>🔍</span>
+                    <span style={{ fontSize: "18px", fontWeight: 600 }}>No challenges found</span>
+                    <span style={{ fontSize: "14px", opacity: 0.7 }}>
+                      Try adjusting your filters or search terms
+                    </span>
+                    {
+                      hasActiveFilters && (
+                        <Button variant="soft" onClick={resetFilters} style={{ marginTop: "8px" }}>
+                        Clear All Filters
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
           ) : (
             filteredChallenges.map((challenge, index) => (
               <tr key={challenge.id}>

--- a/src/ui/components/modules/challenge-list/challenge-list.types.ts
+++ b/src/ui/components/modules/challenge-list/challenge-list.types.ts
@@ -7,6 +7,7 @@ export interface Challenges {
 
 export type DifficultyFilter = "All" | "Easy" | "Medium" | "Hard";
 export type SortOption =
+  | "none"
   | "newest"
   | "oldest"
   | "name-asc"

--- a/src/ui/components/modules/challenge-list/challenge-list.types.ts
+++ b/src/ui/components/modules/challenge-list/challenge-list.types.ts
@@ -1,6 +1,22 @@
 export interface Challenges {
   id: number;
   name: string;
-  difficulty: string;
+  difficulty: "Easy" | "Medium" | "Hard";
   tags: string[];
+}
+
+export type DifficultyFilter = "All" | "Easy" | "Medium" | "Hard";
+export type SortOption =
+  | "newest"
+  | "oldest"
+  | "name-asc"
+  | "name-desc"
+  | "difficulty-asc"
+  | "difficulty-desc";
+
+export interface ChallengeFilters {
+  difficulty: DifficultyFilter;
+  tags: string[];
+  sortBy: SortOption;
+  search: string;
 }

--- a/src/ui/components/modules/challenge-list/challenge-list.utils.ts
+++ b/src/ui/components/modules/challenge-list/challenge-list.utils.ts
@@ -1,4 +1,4 @@
-import { Challenges } from "./challenge-list.types";
+import { Challenges, ChallengeFilters } from "./challenge-list.types";
 
 export const filterChallenges = (challenges: Challenges[], searchQuery: string) => {
   if (!searchQuery.trim()) return challenges;
@@ -10,4 +10,77 @@ export const filterChallenges = (challenges: Challenges[], searchQuery: string) 
       challenge.tags.some((tag) => tag.toLowerCase().includes(query))
     );
   });
+};
+
+export const getAllUniqueTags = (challenges: Challenges[]): string[] => {
+  const tagsSet = new Set<string>();
+  challenges.forEach((challenge) => {
+    challenge.tags.forEach((tag) => tagsSet.add(tag));
+  });
+  return Array.from(tagsSet).sort();
+};
+
+export const filterAndSortChallenges = (
+  challenges: Challenges[],
+  filters: ChallengeFilters,
+): Challenges[] => {
+  let result = [...challenges];
+
+  //1. Filter by search query
+  if (filters.search.trim()) {
+    const query = filters.search.trim().toLowerCase();
+    result = result.filter((challenge) => {
+      return (
+        challenge.name.toLowerCase().includes(query) ||
+        challenge.difficulty.toLowerCase().includes(query) ||
+        challenge.tags.some((tag) => tag.toLowerCase().includes(query))
+      );
+    });
+  }
+
+  //2. Filter by difficulty
+  if (filters.difficulty != "All") {
+    result = result.filter((c) => c.difficulty === filters.difficulty);
+  }
+
+  //3. Filter by tags (AND logic - challenge must have all selected tags)
+  if (filters.tags.length > 0) {
+    result = result.filter((c) => filters.tags.every((tag: string) => c.tags.includes(tag)));
+  }
+
+  //4. Sort
+  switch (filters.sortBy) {
+    case "name-asc":
+      result.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case "name-desc":
+      result.sort((a, b) => b.name.localeCompare(a.name));
+      break;
+    case "difficulty-asc":
+      result.sort((a, b) => difficultyWeight(a.difficulty) - difficultyWeight(b.difficulty));
+      break;
+    case "difficulty-desc":
+      result.sort((a, b) => difficultyWeight(b.difficulty) - difficultyWeight(a.difficulty));
+      break;
+    case "newest":
+      result.sort((a, b) => b.id - a.id);
+      break;
+    case "oldest":
+      result.sort((a, b) => a.id - b.id);
+      break;
+  }
+  return result;
+};
+
+const difficultyWeight = (difficulty: string): number => {
+  switch (difficulty) {
+    case "Easy":
+      return 1;
+    case "Medium":
+      return 2;
+    case "Hard":
+      return 3;
+    default:
+      return 0;
+  }
 };

--- a/src/ui/components/modules/challenge-list/challenge-list.utils.ts
+++ b/src/ui/components/modules/challenge-list/challenge-list.utils.ts
@@ -50,6 +50,9 @@ export const filterAndSortChallenges = (
 
   //4. Sort
   switch (filters.sortBy) {
+    case "none":
+      // Keep original order (no sorting)
+      break;
     case "name-asc":
       result.sort((a, b) => a.name.localeCompare(b.name));
       break;

--- a/src/ui/components/modules/challenge-list/challenge-list.utils.ts
+++ b/src/ui/components/modules/challenge-list/challenge-list.utils.ts
@@ -87,3 +87,20 @@ const difficultyWeight = (difficulty: string): number => {
       return 0;
   }
 };
+
+export const getDfifficultyCounts = (challenges: Challenges[]) => {
+  const counts = {
+    All: challenges.length,
+    Easy: 0,
+    Medium: 0,
+    Hard: 0
+  };
+
+  challenges.forEach((challenge) => {
+    if(challenge.difficulty === "Easy") counts.Easy++;
+    else if(challenge.difficulty === "Medium") counts.Medium++;
+    else if(challenge.difficulty === "Hard") counts.Hard++;
+  });
+
+  return counts;
+}

--- a/src/ui/components/modules/challenge-list/difficulty-filter.tsx
+++ b/src/ui/components/modules/challenge-list/difficulty-filter.tsx
@@ -6,11 +6,17 @@ import { DifficultyFilter as DifficultyFilterType } from "./challenge-list.types
 interface Props {
   selected: DifficultyFilterType;
   onChange: (difficulty: DifficultyFilterType) => void;
+  counts?: {
+    All: number;
+    Easy: number;
+    Medium: number;
+    Hard: number;
+  }
 }
 
 const difficulties: DifficultyFilterType[] = ["All", "Easy", "Medium", "Hard"];
 
-export const DifficultyFilter = ({ selected, onChange }: Props) => {
+export const DifficultyFilter = ({ selected, onChange, counts }: Props) => {
   return (
     <Flex gap="2" wrap="wrap">
       <span style={{ fontWeight: 600, marginRight: 8 }}>Difficulty:</span>
@@ -23,6 +29,7 @@ export const DifficultyFilter = ({ selected, onChange }: Props) => {
           style={{ cursor: "pointer" }}
         >
           {diff}
+          {counts && <span style={{ marginLeft: 4, opacity: 0.7 }}>({counts[diff]})</span>}
         </Button>
       ))}
     </Flex>

--- a/src/ui/components/modules/challenge-list/difficulty-filter.tsx
+++ b/src/ui/components/modules/challenge-list/difficulty-filter.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Button, Flex } from "@radix-ui/themes";
+import { DifficultyFilter as DifficultyFilterType } from "./challenge-list.types";
+
+interface Props {
+  selected: DifficultyFilterType;
+  onChange: (difficulty: DifficultyFilterType) => void;
+}
+
+const difficulties: DifficultyFilterType[] = ["All", "Easy", "Medium", "Hard"];
+
+export const DifficultyFilter = ({ selected, onChange }: Props) => {
+  return (
+    <Flex gap="2" wrap="wrap">
+      <span style={{ fontWeight: 600, marginRight: 8 }}>Difficulty:</span>
+      {difficulties.map((diff) => (
+        <Button
+          key={diff}
+          variant={selected === diff ? "solid" : "soft"}
+          size="2"
+          onClick={() => onChange(diff)}
+          style={{ cursor: "pointer" }}
+        >
+          {diff}
+        </Button>
+      ))}
+    </Flex>
+  );
+};

--- a/src/ui/components/modules/challenge-list/search-bar.tsx
+++ b/src/ui/components/modules/challenge-list/search-bar.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 
 interface Props {
   searchQuery: string;
-  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  setSearchQuery: ((value: string) => void) | React.Dispatch<React.SetStateAction<string>>;
   className?: string;
   style?: React.CSSProperties;
   placeholder?: string;

--- a/src/ui/components/modules/challenge-list/sort-dropdown.tsx
+++ b/src/ui/components/modules/challenge-list/sort-dropdown.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Select } from "@radix-ui/themes";
+import { SortOption } from "./challenge-list.types";
+
+interface Props {
+  value: SortOption;
+  onChange: (value: SortOption) => void;
+}
+
+export const SortDropdown = ({ value, onChange }: Props) => {
+  return (
+    <Select.Root value={value} onValueChange={onChange}>
+      <Select.Trigger placeholder="Sort by..." />
+      <Select.Content>
+        <Select.Group>
+          <Select.Label>Sort by</Select.Label>
+          <Select.Item value="newest">Newest First</Select.Item>
+          <Select.Item value="oldest">Oldest First</Select.Item>
+          <Select.Item value="name-asc">Name (A-Z)</Select.Item>
+          <Select.Item value="name-desc">Name (Z-A)</Select.Item>
+          <Select.Item value="difficulty-asc">Difficulty (Easy → Hard)</Select.Item>
+          <Select.Item value="difficulty-desc">Difficulty (Hard → Easy)</Select.Item>
+        </Select.Group>
+      </Select.Content>
+    </Select.Root>
+  );
+};

--- a/src/ui/components/modules/challenge-list/sort-dropdown.tsx
+++ b/src/ui/components/modules/challenge-list/sort-dropdown.tsx
@@ -15,6 +15,7 @@ export const SortDropdown = ({ value, onChange }: Props) => {
       <Select.Content>
         <Select.Group>
           <Select.Label>Sort by</Select.Label>
+          <Select.Item value="none">Default Order</Select.Item>
           <Select.Item value="newest">Newest First</Select.Item>
           <Select.Item value="oldest">Oldest First</Select.Item>
           <Select.Item value="name-asc">Name (A-Z)</Select.Item>

--- a/src/ui/components/modules/challenge-list/tag-filter.tsx
+++ b/src/ui/components/modules/challenge-list/tag-filter.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Badge, Flex } from "@radix-ui/themes";
+
+interface Props {
+  availableTags: string[];
+  selectedTags: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export const TagFilter = ({ availableTags, selectedTags, onChange }: Props) => {
+  const toggleTag = (tag: string) => {
+    if (selectedTags.includes(tag)) {
+      onChange(selectedTags.filter((t) => t !== tag));
+    } else {
+      onChange([...selectedTags, tag]);
+    }
+  };
+
+  return (
+    <Flex gap="2" wrap="wrap" align="center">
+      <span style={{ fontWeight: 600, marginRight: 8 }}>Tags:</span>
+      {availableTags.map((tag) => (
+        <Badge
+          key={tag}
+          size="2"
+          variant={selectedTags.includes(tag) ? "solid" : "soft"}
+          style={{ cursor: "pointer" }}
+          onClick={() => toggleTag(tag)}
+        >
+          {tag}
+        </Badge>
+      ))}
+    </Flex>
+  );
+};

--- a/src/ui/components/modules/challenge-list/use-challenge-filters.ts
+++ b/src/ui/components/modules/challenge-list/use-challenge-filters.ts
@@ -13,7 +13,7 @@ export const useChallengeFilters = () => {
   const filters: ChallengeFilters = useMemo(() => {
     const difficulty = (searchParams.get("difficulty") || "All") as DifficultyFilter;
     const tags = searchParams.get("tags")?.split(",").filter(Boolean) || [];
-    const sortBy = (searchParams.get("sort") || "newest") as SortOption;
+    const sortBy = (searchParams.get("sort") || "none") as SortOption;
     const search = searchParams.get("search") || "";
 
     return { difficulty, tags, sortBy, search };
@@ -39,7 +39,7 @@ export const useChallengeFilters = () => {
         params.delete("tags");
       }
 
-      if (merged.sortBy !== "newest") {
+      if (merged.sortBy !== "none") {
         params.set("sort", merged.sortBy);
       } else {
         params.delete("sort");

--- a/src/ui/components/modules/challenge-list/use-challenge-filters.ts
+++ b/src/ui/components/modules/challenge-list/use-challenge-filters.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import { ChallengeFilters, DifficultyFilter, SortOption } from "./challenge-list.types";
+
+export const useChallengeFilters = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  //Parse current filters from URL
+  const filters: ChallengeFilters = useMemo(() => {
+    const difficulty = (searchParams.get("difficulty") || "All") as DifficultyFilter;
+    const tags = searchParams.get("tags")?.split(",").filter(Boolean) || [];
+    const sortBy = (searchParams.get("sort") || "newest") as SortOption;
+    const search = searchParams.get("search") || "";
+
+    return { difficulty, tags, sortBy, search };
+  }, [searchParams]);
+
+  //Update URL with new filters
+  const updateFilters = useCallback(
+    (newFilters: Partial<ChallengeFilters>) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      const merged = { ...filters, ...newFilters };
+
+      // Update or remove params
+      if (merged.difficulty !== "All") {
+        params.set("difficulty", merged.difficulty);
+      } else {
+        params.delete("difficulty");
+      }
+
+      if (merged.tags.length > 0) {
+        params.set("tags", merged.tags.join(","));
+      } else {
+        params.delete("tags");
+      }
+
+      if (merged.sortBy !== "newest") {
+        params.set("sort", merged.sortBy);
+      } else {
+        params.delete("sort");
+      }
+
+      if (merged.search.trim()) {
+        params.set("search", merged.search);
+      } else {
+        params.delete("search");
+      }
+
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [filters, pathname, router, searchParams],
+  );
+
+  const resetFilters = useCallback(() => {
+    router.push(pathname, { scroll: false });
+  }, [pathname, router]);
+
+  return { filters, updateFilters, resetFilters };
+};


### PR DESCRIPTION
**Description**

This PR contains the following points:

- This PR adds comprehensive filtering and sorting functionality to the challenge list page (`/challenges`), significantly improving user experience and challenge discoverability.
<img width="1470" height="881" alt="image" src="https://github.com/user-attachments/assets/ead520ee-4d46-4a1b-846a-c653ef8a553a" />
<img width="1470" height="881" alt="image" src="https://github.com/user-attachments/assets/790d4eb4-b714-474e-84d0-9f97da35ceac" />
<img width="1470" height="881" alt="image" src="https://github.com/user-attachments/assets/7003a576-feb7-4ca9-bc5c-f6bd0902669a" />
