### PR TITLE
feat: challenge stats dashboard on the challenges pages

### DIFF
--- a/src/ui/components/modules/challenge-list/challenge-list.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-list.tsx
@@ -13,6 +13,7 @@ import { TagFilter } from "./tag-filter";
 import { SortDropdown } from "./sort-dropdown";
 import { Flex, Button, Badge } from "@radix-ui/themes";
 import { ActiveFilters } from "./active-filters";
+import { ChallengeStats } from "./challenge-stats";
 
 export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
   const { filters, updateFilters, resetFilters } = useChallengeFilters();
@@ -33,12 +34,16 @@ export function ChallengeList({ challenges }: { challenges: Challenges[] }) {
 
   return (
     <div>
+      {/* Challenge stats Dashboard */}
+      <ChallengeStats 
+      challenges={challenges}
+      />
       {/* Search Bar */}
       <SearchBar
         searchQuery={filters.search}
         setSearchQuery={(search: string) => updateFilters({ search })}
       />
-
+      
       {/* Filters Section */}
       <Flex direction="column" gap="4" style={{ marginTop: 24, marginBottom: 24, padding: "0 5%" }}>
         <Flex justify="between" align="center" wrap="wrap" gap="3">

--- a/src/ui/components/modules/challenge-list/challenge-stats.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-stats.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Card, Flex, Text, Progress } from "@radix-ui/themes";
+import { Challenges } from "./challenge-list.types";
+
+interface Props {
+  challenges: Challenges[];
+}
+
+export const ChallengeStats = ({ challenges }: Props) => {
+  const getDifficultyStats = (difficulty: "Easy" | "Medium" | "Hard") => {
+    const total = challenges.filter((c) => c.difficulty === difficulty).length;
+    const solved = 0; // TODO: Replace with actual solved count when user progress tracking is implemented
+    return { solved, total, percentage: total > 0 ? (solved / total) * 100 : 0 };
+  };
+
+  const easyStats = getDifficultyStats("Easy");
+  const mediumStats = getDifficultyStats("Medium");
+  const hardStats = getDifficultyStats("Hard");
+
+  const getDifficultyColor = (difficulty: "Easy" | "Medium" | "Hard") => {
+    switch (difficulty) {
+      case "Easy":
+        return "green";
+      case "Medium":
+        return "yellow";
+      case "Hard":
+        return "red";
+    }
+  };
+
+  return (
+    <Flex gap="3" style={{ margin: "24px 0", padding: "0 16px" }}>
+      {/* Easy */}
+      <Card style={{ padding: 16, flex: 1 }}>
+        <Flex direction="column" gap="2">
+          <Flex justify="between" align="center">
+            <Text size="2" weight="medium" color="green">
+              Easy
+            </Text>
+            <Text size="2" weight="bold">
+              {easyStats.solved}/{easyStats.total}
+            </Text>
+          </Flex>
+          <Progress
+            value={easyStats.percentage}
+            color={getDifficultyColor("Easy")}
+            size="1"
+          />
+        </Flex>
+      </Card>
+
+      {/* Medium */}
+      <Card style={{ padding: 16, flex: 1 }}>
+        <Flex direction="column" gap="2">
+          <Flex justify="between" align="center">
+            <Text size="2" weight="medium" color="yellow">
+              Medium
+            </Text>
+            <Text size="2" weight="bold">
+              {mediumStats.solved}/{mediumStats.total}
+            </Text>
+          </Flex>
+          <Progress
+            value={mediumStats.percentage}
+            color={getDifficultyColor("Medium")}
+            size="1"
+          />
+        </Flex>
+      </Card>
+
+      {/* Hard */}
+      <Card style={{ padding: 16, flex: 1 }}>
+        <Flex direction="column" gap="2">
+          <Flex justify="between" align="center">
+            <Text size="2" weight="medium" color="red">
+              Hard
+            </Text>
+            <Text size="2" weight="bold">
+              {hardStats.solved}/{hardStats.total}
+            </Text>
+          </Flex>
+          <Progress
+            value={hardStats.percentage}
+            color={getDifficultyColor("Hard")}
+            size="1"
+          />
+        </Flex>
+      </Card>
+    </Flex>
+  );
+};

--- a/src/ui/components/modules/challenge-list/challenge-stats.tsx
+++ b/src/ui/components/modules/challenge-list/challenge-stats.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Card, Flex, Text, Progress } from "@radix-ui/themes";
+import { Flex } from "@radix-ui/themes";
 import { Challenges } from "./challenge-list.types";
+import { DifficultyStatCard } from "./difficulty-stat-card";
 
 interface Props {
   challenges: Challenges[];
@@ -14,79 +15,23 @@ export const ChallengeStats = ({ challenges }: Props) => {
     return { solved, total, percentage: total > 0 ? (solved / total) * 100 : 0 };
   };
 
-  const easyStats = getDifficultyStats("Easy");
-  const mediumStats = getDifficultyStats("Medium");
-  const hardStats = getDifficultyStats("Hard");
-
-  const getDifficultyColor = (difficulty: "Easy" | "Medium" | "Hard") => {
-    switch (difficulty) {
-      case "Easy":
-        return "green";
-      case "Medium":
-        return "yellow";
-      case "Hard":
-        return "red";
-    }
-  };
+  const difficultyStats = [
+    { difficulty: "Easy" as const, ...getDifficultyStats("Easy") },
+    { difficulty: "Medium" as const, ...getDifficultyStats("Medium") },
+    { difficulty: "Hard" as const, ...getDifficultyStats("Hard") },
+  ];
 
   return (
     <Flex gap="3" style={{ margin: "24px 0", padding: "0 16px" }}>
-      {/* Easy */}
-      <Card style={{ padding: 16, flex: 1 }}>
-        <Flex direction="column" gap="2">
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium" color="green">
-              Easy
-            </Text>
-            <Text size="2" weight="bold">
-              {easyStats.solved}/{easyStats.total}
-            </Text>
-          </Flex>
-          <Progress
-            value={easyStats.percentage}
-            color={getDifficultyColor("Easy")}
-            size="1"
-          />
-        </Flex>
-      </Card>
-
-      {/* Medium */}
-      <Card style={{ padding: 16, flex: 1 }}>
-        <Flex direction="column" gap="2">
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium" color="yellow">
-              Medium
-            </Text>
-            <Text size="2" weight="bold">
-              {mediumStats.solved}/{mediumStats.total}
-            </Text>
-          </Flex>
-          <Progress
-            value={mediumStats.percentage}
-            color={getDifficultyColor("Medium")}
-            size="1"
-          />
-        </Flex>
-      </Card>
-
-      {/* Hard */}
-      <Card style={{ padding: 16, flex: 1 }}>
-        <Flex direction="column" gap="2">
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium" color="red">
-              Hard
-            </Text>
-            <Text size="2" weight="bold">
-              {hardStats.solved}/{hardStats.total}
-            </Text>
-          </Flex>
-          <Progress
-            value={hardStats.percentage}
-            color={getDifficultyColor("Hard")}
-            size="1"
-          />
-        </Flex>
-      </Card>
+      {difficultyStats.map((stat) => (
+        <DifficultyStatCard
+          key={stat.difficulty}
+          difficulty={stat.difficulty}
+          solved={stat.solved}
+          total={stat.total}
+          percentage={stat.percentage}
+        />
+      ))}
     </Flex>
   );
 };

--- a/src/ui/components/modules/challenge-list/difficulty-stat-card.tsx
+++ b/src/ui/components/modules/challenge-list/difficulty-stat-card.tsx
@@ -1,0 +1,27 @@
+import { Card, Flex, Text, Progress } from "@radix-ui/themes";
+import { getDifficultyColor } from "@/ui/utils/challenge";
+
+interface Props {
+  difficulty: "Easy" | "Medium" | "Hard";
+  solved: number;
+  total: number;
+  percentage: number;
+}
+
+export const DifficultyStatCard = ({ difficulty, solved, total, percentage }: Props) => {
+  return (
+    <Card style={{ padding: 16, flex: 1 }}>
+      <Flex direction="column" gap="2">
+        <Flex justify="between" align="center">
+          <Text size="2" weight="medium" color={getDifficultyColor(difficulty)}>
+            {difficulty}
+          </Text>
+          <Text size="2" weight="bold">
+            {solved}/{total}
+          </Text>
+        </Flex>
+        <Progress value={percentage} color={getDifficultyColor(difficulty)} size="1" />
+      </Flex>
+    </Card>
+  );
+};

--- a/src/ui/utils/challenge.ts
+++ b/src/ui/utils/challenge.ts
@@ -1,0 +1,10 @@
+export const getDifficultyColor = (difficulty: "Easy" | "Medium" | "Hard") => {
+  switch (difficulty) {
+    case "Easy":
+      return "green";
+    case "Medium":
+      return "yellow";
+    case "Hard":
+      return "red";
+  }
+};


### PR DESCRIPTION
**Description**

This PR contains the following points:
- Implemented the stats dashboard on the challenges page using cards which will show the total solved and number of problems and the progress bar which will be indicating the progress on the problems.

<img width="2936" height="1620" alt="image" src="https://github.com/user-attachments/assets/d99779db-7b06-45ba-8110-6276cef259e4" />

